### PR TITLE
Update README.md - Improved Power Off Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gcode:
                              device="tasmota_plug",
                              state="off")}
 ```
-   Or for ON-OFF control using a Relay then:
+   Or for remote ON-OFF control of the Printer using a Relay:
 ```
 [gcode_macro _POWER_OFF_PRINTER]
 gcode:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ type: tasmota
 address: 192.168.0.12
 password: ******
 ```
-   Example of Moonraker configuration for **Relay** controlled via **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
+   Example of Moonraker config for **Relay** controlled via **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
 ```
 [power printer]
 type: gpio

--- a/README.md
+++ b/README.md
@@ -27,31 +27,38 @@ After that we would need to create a delayed gcode macro. In this macro will add
 ```
 [delayed_gcode POWER_OFF_PRINTER_CHECK]
 gcode:
-  {% if printer.idle_timeout.state == "Idle" or printer.idle_timeout.state == "Ready" %}
-    {% if printer.extruder.temperature < 50.0 and printer.heater_bed.temperature < 50.0 %}
-        {% if printer.extruder.target == 0.0 and printer.heater_bed.target == 0.0 %}
+   {% set idle_state = printer.idle_timeout.state | string %}
+   {% set e_target = printer.extruder.target | float | round(1) %}
+   {% set bed_target = printer.heater_bed.target | float | round(1) %}
+   {% set msg_only_once = printer["gcode_macro ACTIVATE_POWER_OFF"].msg_only_once | int %}
+   {% if msg_only_once == 0 %}
+      M118 Printer shutdown is active: Waiting for the extruder to cool down to 50°C, then the printer will be turned off.
+      SET_GCODE_VARIABLE MACRO=ACTIVATE_POWER_OFF VARIABLE=msg_only_once VALUE=1  
+   {% endif %}  
+   {% if idle_state == "Idle" or idle_state == "Ready" %}
+      {% if printer.extruder.temperature < 50.0 and printer.heater_bed.temperature < 50.0 %}
+         {% if e_target == 0.0 and bed_target == 0.0 %}
             UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
+            SET_GCODE_VARIABLE MACRO=ACTIVATE_POWER_OFF VARIABLE=msg_only_once VALUE=0
             _POWER_OFF_PRINTER
-        {% else %}
-            UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=2
-        {% endif %}
-    {% else %}
-        {% if printer.idle_timeout.state == "Printing" %}
-            UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
-        {% else %}
-            {% if printer.extruder.target == 0.0 and printer.heater_bed.target == 0.0 %}
-                UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=2
-            {% else %}
-                UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
-            {% endif %}
-        {% endif %}
-    {% endif %}
-  {% endif %}
+         {% endif %}	
+      {% elif e_target == 0.0 and bed_target == 0.0 %}
+         UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=2
+      {% elif e_target > 0.0 or bed_target > 0.0 %}
+         UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
+         M118 The scheduled printer shutdown has been canceled: Temperature interaction by the user.
+      {% else %}
+         UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
+      {% endif %}	  
+   {% elif idle_state == "Printing" %}
+      UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
+      M118 The scheduled printer shutdown has been canceled: User-side print interaction.	  
+   {% endif %}
 ```
 
-The only thing left is to add the following command to your print end macro, that will set a 30 second timer:
+The only thing left is to add the following macro to your print end gcode. This will run the entire verification procedure to ensure it is safe to turn off the printer (the same macro is used for the button):
 ```
-UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=30
+ACTIVATE_POWER_OFF
 ```
 
 And that is it. Now after your print has finished, the printer will cooldown and once the temperature is below 50 degrees Celsius it will self-shutdown.
@@ -60,19 +67,23 @@ And that is it. Now after your print has finished, the printer will cooldown and
 In order to achive this you would need to add the following Macros:
 ```
 [gcode_macro ACTIVATE_POWER_OFF]
+variable_msg_only_once: 0
 gcode:
-    UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=60
+   SET_GCODE_VARIABLE MACRO=ACTIVATE_POWER_OFF VARIABLE=msg_only_once VALUE=0
+   UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=60
 
 [gcode_macro DEACTIVATE_POWER_OFF]
 gcode:
-    UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=0
+   UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=0
+   UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=0
 
 [delayed_gcode POWER_OFF_PRINTER_CHECK_ACT]
 gcode:
-  {% if printer.idle_timeout.state == "Idle" or printer.idle_timeout.state == "Ready" %}
-    UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=30
-  {% else %}
-    UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=60
-  {% endif %}
+   {% set idle_state = printer.idle_timeout.state | string %}
+   {% if (idle_state == "Idle" or idle_state == "Ready") and printer.print_stats.state != "paused" %}
+      UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK DURATION=30
+   {% else %}
+      UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=60
+   {% endif %}
 ```
 By clicking running Activate Power Off macro while the printer is running the macro will check every 60 seconds if the printer has finished. 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ gcode:
                              device="tasmota_plug",
                              state="off")}
 ```
-
+   Or for ON-OFF control using a Relay then:
+```
+[gcode_macro _POWER_OFF_PRINTER]
+gcode:
+   {action_call_remote_method("set_device_power", device="printer", state="off")}
+```
 After that we would need to create a delayed gcode macro. In this macro will add logic that will check if both the bed and the hot end are below 50 degrees Celsius. If you start printing or start heating up the bed or hot end the automatic shutdown will be stopped. 
 ```
 [delayed_gcode POWER_OFF_PRINTER_CHECK]

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ type: tasmota
 address: 192.168.0.12
 password: ******
 ```
-   Example of ```moonraker.conf``` for remote ON-OFF control of the printer using **Relay** and **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
+   Example of ```moonraker.conf``` for remote ON-OFF control of the printer using **Relay** and **GPIO**:
 ```
 [power printer]
 type: gpio
-pin: gpiochip0/gpio72              # can be revesed by "!" , BTT-PI GPIO pin PC8
+pin: gpiochip0/gpio72              # can be revesed by "!" , Bigtreetech Pi V1.2 GPIO pin PC8
 initial_state: off  
 off_when_shutdown: True            # Turning off when a shutdown/error occurs 
 locked_while_printing: True        # Preventing you from turning it off during a print
@@ -102,4 +102,4 @@ gcode:
       UPDATE_DELAYED_GCODE ID=POWER_OFF_PRINTER_CHECK_ACT DURATION=60
    {% endif %}
 ```
-By clicking running Activate Power Off macro while the printer is running the macro will check every 60 seconds if the printer has finished. 
+By clicking running ```ACTIVATE_POWER_OFF``` macro while the printer is running the macro will check every 60 seconds if the printer has finished. 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ type: tasmota
 address: 192.168.0.12
 password: ******
 ```
-   Example of Moonraker config for **Relay** controlled via **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
+   Example of ```moonraker.conf``` for remote ON-OFF control of the printer using **Relay** and **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
 ```
 [power printer]
 type: gpio
@@ -33,7 +33,7 @@ gcode:
                              device="tasmota_plug",
                              state="off")}
 ```
-   Or for remote ON-OFF control of the Printer using a Relay:
+   Or for control using **Relay** then:
 ```
 [gcode_macro _POWER_OFF_PRINTER]
 gcode:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,18 @@ type: tasmota
 address: 192.168.0.12
 password: ******
 ```
-
+   Example of Moonraker configuration for **Relay** controlled via **GPIO** (pin: PC8 on Bigtreetech Pi V1.2):
+```
+[power printer]
+type: gpio
+pin: gpiochip0/gpio72              # can be revesed by "!" , BTT-PI GPIO pin PC8
+initial_state: off  
+off_when_shutdown: True            # Turning off when a shutdown/error occurs 
+locked_while_printing: True        # Preventing you from turning it off during a print
+restart_klipper_when_powered: True
+restart_delay: 1
+bound_service: klipper             # Making sure the Klipper service is started/restarted with the toggle
+```
 # Klipper configuration
 Then we would need to configure klipper, by first testing connecting the wifi socket. I have personally created a hidden Macro for this:
 


### PR DESCRIPTION
- Fix for ```{% if printer.idle_timeout.state == "Printing" %}``` condition in the ```_CHECK``` macro (```"printer.idle_timeout.state"``` hereinafter abbreviated as ```"idle_state"```): The condition was never met in the original code. It has now been moved outside the main condition ```{% if idle_state == "Idle" or idle_state == "Ready" %}``` to ensure it works as intended.
Note: In the original code, when a new print started, the ```{% if idle_state == "Printing" %}``` condition did not interrupt the loop as expected. This was because the **"printing"** state did not satisfy the main condition ```{% if idle_state == "Idle" or idle_state == "Ready" %}```, preventing any nested conditions from setting ```DURATION=0``` to stop the loop. While the loop still functioned, it did so unintentionally—by failing to meet the main condition, no other conditions were triggered, and ```DURATION=2``` was never set.

- Added user-friendly ```M118``` messages.

- Improved logic to prevent ```POWER_OFF_PRINTER_CHECK``` delayed gcode loop from running on ```PAUSE```.

- ```DEACTIVATE_POWER_OFF``` macro now also terminates the second loop (now both ```CHECK_ACT``` and ```_CHECK)```.

- Proposed change for End G-code: A suggested improvement for the print end sequence, using ```ACTIVATE_POWER_OFF``` instead of ```POWER_OFF_PRINTER_CHECK``` to run the full verification process and ensure it is safe to turn off the printer.